### PR TITLE
fix: restore production deployment pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ bun run synth
 - A retained customer-managed KMS key for SSM
 - The existing Route 53 public zone, imported as `Z32YJCERCJ1WLI`
 - Production apex/`www` and legacy `carolyn.diloreto.com` Amplify associations with permanent canonical redirects
-- GitHub Actions OIDC trust restricted to this repository's `main` ref
+- GitHub Actions OIDC trust restricted to this repository's `production` environment, whose deployment branch policy allows only `main`
 - An Amplify-only deployment role
 - Fourteen-day SSR log retention, a minimal 5xx alarm, and email notifications
 - An account-wide $5 monthly actual/forecast AWS budget warning
@@ -181,6 +181,8 @@ Before provisioning production DNS or relying on Amplify:
 ### Configure GitHub deployment variables
 
 Create a GitHub Actions environment named `production`, restrict it to the selected `main` branch, and leave required reviewers disabled so validated main deployments remain automatic. The deployment job references this environment even though it needs no application credential; production password smoke coverage runs against the hermetic fixture artifact instead of storing a real project password in GitHub.
+
+GitHub includes the environment, rather than the branch ref, in an environment job's OIDC subject. The deployment role therefore trusts exactly `repo:soodoh/carolyn-portfolio:environment:production`. If the job's environment name changes, update the CDK trust policy and deploy the stack before running the workflow again.
 
 Read stack outputs, then configure non-secret repository variables:
 

--- a/infra/lib/hosting-stack.ts
+++ b/infra/lib/hosting-stack.ts
@@ -404,7 +404,7 @@ export class HostingStack extends Stack {
 			StringEquals: {
 				"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
 				"token.actions.githubusercontent.com:sub": [
-					"repo:soodoh/carolyn-portfolio:ref:refs/heads/main",
+					"repo:soodoh/carolyn-portfolio:environment:production",
 				],
 			},
 		};
@@ -414,7 +414,7 @@ export class HostingStack extends Stack {
 				githubSubjectConditions,
 			),
 			description:
-				"Allows Carolyn Portfolio main-branch workflows to release and monitor Amplify production",
+				"Allows the Carolyn Portfolio production environment to release and monitor Amplify production",
 		});
 		deploymentRole.addToPolicy(
 			new PolicyStatement({

--- a/infra/test/hosting-stack.unit.ts
+++ b/infra/test/hosting-stack.unit.ts
@@ -285,7 +285,7 @@ describe("HostingStack production resources", () => {
 						StringEquals: {
 							"token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
 							"token.actions.githubusercontent.com:sub": [
-								"repo:soodoh/carolyn-portfolio:ref:refs/heads/main",
+								"repo:soodoh/carolyn-portfolio:environment:production",
 							],
 						},
 					},

--- a/scripts/verify-prerender-output.ts
+++ b/scripts/verify-prerender-output.ts
@@ -145,11 +145,12 @@ if (artifactMode === "fixture") {
 	);
 }
 
-if (
-	artifactMode === "production" &&
-	process.env.HERMETIC_PRODUCTION_BUILD !== "true"
-) {
-	for (const file of artifactInspectableFiles) {
+if (artifactMode === "production") {
+	const productionAssetFiles =
+		process.env.HERMETIC_PRODUCTION_BUILD === "true"
+			? [join(amplifyRoot, "compute", "default", "index.mjs")]
+			: artifactInspectableFiles;
+	for (const file of productionAssetFiles) {
 		if ((await readFile(file, "utf8")).includes("/test-assets/")) {
 			throw new Error(
 				`Production artifact contains a local visual asset reference: ${file}`,

--- a/tests/unit/deployment-workflow.unit.ts
+++ b/tests/unit/deployment-workflow.unit.ts
@@ -11,6 +11,10 @@ const amplifyConfigPath = new URL(
 );
 const packagePath = new URL("../../package.json", import.meta.url);
 const amplifySmokePath = new URL("../amplify.smoke.ts", import.meta.url);
+const hostingStackPath = new URL(
+	"../../infra/lib/hosting-stack.ts",
+	import.meta.url,
+);
 
 describe("production deployment workflow", () => {
 	test("rechecks release ownership immediately before starting Amplify", async () => {
@@ -75,6 +79,21 @@ describe("production deployment workflow", () => {
 		);
 	});
 
+	test("matches AWS OIDC trust to the deployment environment", async () => {
+		const [workflow, hostingStack] = await Promise.all([
+			readFile(workflowPath, "utf8"),
+			readFile(hostingStackPath, "utf8"),
+		]);
+
+		expect(workflow).toContain("environment: production");
+		expect(hostingStack).toContain(
+			'"repo:soodoh/carolyn-portfolio:environment:production"',
+		);
+		expect(hostingStack).not.toContain(
+			'"repo:soodoh/carolyn-portfolio:ref:refs/heads/main"',
+		);
+	});
+
 	test("uses a production-shaped fixture suite without production passwords", async () => {
 		const [workflow, packageJson, amplifySmoke] = await Promise.all([
 			readFile(workflowPath, "utf8"),
@@ -86,7 +105,6 @@ describe("production deployment workflow", () => {
 			workflow.indexOf("  playwright:"),
 			workflow.indexOf("  release-production-ref:"),
 		);
-		expect(workflow).toContain("environment: production");
 		expect(playwrightJob).toContain("oven-sh/setup-bun@");
 		expect(playwrightJob).toContain("run: bun install --frozen-lockfile");
 		expect(playwrightJob).toContain("run: bun run test:visual");

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,13 +4,16 @@ import viteReact from "@vitejs/plugin-react";
 import { nitro } from "nitro/vite";
 import { defineConfig, loadEnv } from "vite";
 import { getStaticPublicPaths } from "./lib/amplify-artifact";
+import { getArtifactMode } from "./lib/build-environment";
 
 const staticPublicPaths = new Set(getStaticPublicPaths());
 
 export default defineConfig(({ mode }) => {
 	Object.assign(process.env, loadEnv(mode, process.cwd(), ""));
+	const artifactMode = getArtifactMode(process.env);
 
 	return {
+		publicDir: false,
 		define: {
 			"process.env.RELEASE_COMMIT": JSON.stringify(
 				process.env.AWS_COMMIT_ID ?? process.env.GITHUB_SHA ?? "local",
@@ -32,6 +35,14 @@ export default defineConfig(({ mode }) => {
 			nitro({
 				preset: "aws_amplify",
 				awsAmplify: { runtime: "nodejs24.x" },
+				publicAssets: [
+					{
+						dir: "public",
+						maxAge: 0,
+						ignore:
+							artifactMode === "production" ? ["public/test-assets/**"] : [],
+					},
+				],
 			}),
 			tanstackStart({
 				prerender: {


### PR DESCRIPTION
## Summary

- align the AWS deployment role trust policy with GitHub's `production` environment OIDC subject
- exclude checked-in visual fixtures from Nitro's production public-asset manifest
- strengthen production artifact verification and add regression coverage for the workflow/trust-policy contract
- document the environment-specific OIDC behavior

The live CDK stack has already been updated and now reports zero infrastructure drift. After that update, the latest workflow authenticated to AWS successfully and exposed the separate Nitro asset-manifest failure addressed by this PR.

## Validation

- `bun run validate` — passed
- `bun run lint` — passed after rebasing onto latest `main`
- `bun run test:unit` — 116 passed after rebasing
- `cd infra && bun run typecheck && bun run test && bun run synth -- --quiet` — passed; 9 infrastructure tests
- `cd infra && bun run diff -- --quiet` — zero stack differences after deployment

## Risk

Low. Production builds now let Nitro own public asset copying and omit only `public/test-assets/**`; fixture-mode builds retain those assets and continue to pass artifact smoke tests. No UI changes or screenshots required.
